### PR TITLE
chore: remove unused WeierstrassCurve constraint

### DIFF
--- a/symbolic-base/src/ZkFold/Base/Algebra/EllipticCurve/Class.hs
+++ b/symbolic-base/src/ZkFold/Base/Algebra/EllipticCurve/Class.hs
@@ -212,8 +212,7 @@ deriving newtype instance HasPointInf point
 deriving newtype instance Planar field point
   => Planar field (Weierstrass curve point)
 instance
-  ( WeierstrassCurve curve field
-  , Conditional (BooleanOf field) (BooleanOf field)
+  ( Conditional (BooleanOf field) (BooleanOf field)
   , Conditional (BooleanOf field) field
   , Eq field
   , Field field


### PR DESCRIPTION
This thing is still dangling apparently because parameter `a` was used earlier.